### PR TITLE
Config the pnpm to not modify lock file

### DIFF
--- a/dev/watch.sh
+++ b/dev/watch.sh
@@ -4,6 +4,6 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 CDIR=$( pwd )
 cd $DIR
 
-docker-compose exec -w /var/www/src mapas bash -c "pnpm install --recursive && pnpm run watch"
+docker-compose exec -w /var/www/src mapas bash -c "pnpm install --no-lockfile --recursive && pnpm run watch"
 
 cd $CDIR

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -35,7 +35,7 @@ fi
 
 if [ $BUILD_ASSETS = "1" ]; then
     cd /var/www/src
-    pnpm install --recursive 
+    pnpm install --recursive --no-lockfile
     pnpm run dev
 fi
 


### PR DESCRIPTION
Garante que o pnpm não fique alterando o arquivo pnpm-lock.yaml sempre que subirmos o ambiente em dev