### PR TITLE
Fix breadcrumb links to reflect correct navigation.

### DIFF
--- a/src/modules/Search/views/search/agent.php
+++ b/src/modules/Search/views/search/agent.php
@@ -18,7 +18,7 @@ $this->import('
 
 $this->breadcrumb = [
     ['label' => i::__('Inicio'), 'url' => $app->createUrl('site', 'index')],
-    ['label' => i::__('Agentes'), 'url' => $app->createUrl('agents')],
+    ['label' => i::__('Agentes'), 'url' => $app->createUrl('agentes')],
 ]; 
 ?>
 <search page-title="<?php i::esc_attr_e('Agentes') ?>" entity-type="agent" :initial-pseudo-query="{'term:area':[]}">

--- a/src/modules/Search/views/search/event.php
+++ b/src/modules/Search/views/search/event.php
@@ -19,7 +19,7 @@ $this->import('
 
 $this->breadcrumb = [
     ['label' => i::__('Inicio'), 'url' => $app->createUrl('site', 'index')],
-    ['label' => i::__('Eventos'), 'url' => $app->createUrl('events')],
+    ['label' => i::__('Eventos'), 'url' => $app->createUrl('eventos')],
 ];
 ?>
 <search page-title="<?php i::esc_attr_e('Eventos') ?>" entity-type="event" :initial-pseudo-query="{'event:term:linguagem':[],'event:term:linguagem':[], 'event:classificacaoEtaria': []}">

--- a/src/modules/Search/views/search/opportunity.php
+++ b/src/modules/Search/views/search/opportunity.php
@@ -11,7 +11,7 @@ $this->import('
 
 $this->breadcrumb = [
     ['label'=> i::__('Inicio'), 'url' => $app->createUrl('site', 'index')],
-    ['label'=> i::__('Oportunidades'), 'url' => $app->createUrl('opportunities')],
+    ['label'=> i::__('Oportunidades'), 'url' => $app->createUrl('oportunidades')],
 ];
 ?>
 <search page-title="<?php i::esc_attr_e('Oportunidades') ?>" entity-type="opportunity" :initial-pseudo-query="{type:[],'term:area':[]}"> 

--- a/src/modules/Search/views/search/project.php
+++ b/src/modules/Search/views/search/project.php
@@ -12,7 +12,7 @@ $this->import('
 
 $this->breadcrumb = [
     ['label' => i::__('Inicio'), 'url' => $app->createUrl('site', 'index')],
-    ['label' => i::__('Projetos'), 'url' => $app->createUrl('projects')],
+    ['label' => i::__('Projetos'), 'url' => $app->createUrl('projetos')],
 ];
 ?>
 

--- a/src/modules/Search/views/search/space.php
+++ b/src/modules/Search/views/search/space.php
@@ -18,7 +18,7 @@ $this->import('
 
 $this->breadcrumb = [
     ['label'=> i::__('Inicio'), 'url' => $app->createUrl('site', 'index')],
-    ['label'=> i::__('Espaços'), 'url' => $app->createUrl('spaces')],
+    ['label'=> i::__('Espaços'), 'url' => $app->createUrl('espacos')],
 ];
 ?>
 <search page-title="<?php i::esc_attr_e('Espaços') ?>" entity-type="space" :initial-pseudo-query="{'term:area':[], type:[]}">    


### PR DESCRIPTION
Fixes the breadcrumb links for agent, event, opportunity, project, and space.

The breadcrumb links were pointing to incorrect destinations, leading to improper navigation on the detail pages. This correction adjusts the links to correctly point to the pages for agents, events, opportunities, projects, and spaces.