### PR TITLE
Adds patch endpoint for agent

### DIFF
--- a/app/routes/api/agent.php
+++ b/app/routes/api/agent.php
@@ -16,6 +16,7 @@ return [
     ],
     '/api/v2/agents/{id}' => [
         Request::METHOD_GET => [AgentApiController::class, 'getOne'],
+        Request::METHOD_PATCH => [AgentApiController::class, 'patch'],
         Request::METHOD_DELETE => [AgentApiController::class, 'delete'],
     ],
     '/api/v2/agents/{id}/opportunities' => [

--- a/app/src/Controller/Api/AgentApiController.php
+++ b/app/src/Controller/Api/AgentApiController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Controller\Api;
 
+use App\Exception\ResourceNotFoundException;
 use App\Repository\AgentRepository;
 use App\Request\AgentRequest;
 use App\Service\AgentService;
@@ -65,6 +66,20 @@ class AgentApiController
             return new JsonResponse($responseData, 201);
         } catch (Exception $exception) {
             return new JsonResponse(['error' => $exception->getMessage()], 400);
+        }
+    }
+
+    public function patch(array $params): JsonResponse
+    {
+        try {
+            $agentData = $this->agentRequest->validateUpdate();
+            $agent = $this->agentService->update((int) $params['id'], (object) $agentData);
+
+            return new JsonResponse($agent, Response::HTTP_CREATED);
+        } catch (ResourceNotFoundException $exception) {
+            return new JsonResponse(['error' => $exception->getMessage()], Response::HTTP_NOT_FOUND);
+        } catch (Exception $exception) {
+            return new JsonResponse(['error' => $exception->getMessage()], Response::HTTP_BAD_REQUEST);
         }
     }
 

--- a/app/src/Request/AgentRequest.php
+++ b/app/src/Request/AgentRequest.php
@@ -35,4 +35,12 @@ class AgentRequest
 
         return $data;
     }
+
+    public function validateUpdate(): array
+    {
+        return json_decode(
+            json: $this->request->getContent(),
+            associative: true
+        );
+    }
 }


### PR DESCRIPTION
#145 


**Campos que não estão sendo atualizados:**

- CPF
- CNPJ
- E-mail pessoal
- Telefone privado 1 com DDD
- Telefone privado 2 com DDD
- Complemento ou ponto de referência
- Data de nascimento
- Gênero
- Orientação sexual
- Raça/Cor
- Agente itinerante
- Tipo da conta bancária
- Dados bancários
- Comunidades tradicionais

**Campos que requerem validações específicas:**

- Site
- CPF
- CNPJ
- E-mail pessoal
- Telefone público
- E-mail público
- Telefone privado 1 com DDD
- Telefone privado 2 com DDD
- CEP

**Eventos incomuns:**

O campo `publicLocation` não atualiza no navegador, mas é atualizado no endpoint, que por sua vez atualiza no navegador.

**Não foram testados**

- Os campos de enviar imagens e arquivos.