### PR TITLE
Remove asterisk from Tag field

### DIFF
--- a/src/modules/Entities/components/entity-terms/template.php
+++ b/src/modules/Entities/components/entity-terms/template.php
@@ -16,7 +16,7 @@ $this->import('
 <div v-if="taxomyExists() && (editable || entity.terms?.[taxonomy].length > 0)" :class="['entity-terms', classes, error]">
     <div class="entity-terms__header">
         <mc-title tag="h4" :short-length="0" size="medium" class="bold">{{title ?? taxonomy}}</mc-title>
-        <span class="entity-terms__required" style="color: red">*</span>
+        <span class="entity-terms__required" style="color: red" v-if="title !== 'Tags'">*</span>
     </div>
  
     <mc-popover v-if="allowInsert && editable" openside="down-right"  @open="loadTerms()" :title="popoverTitle">


### PR DESCRIPTION
| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Branch?       |fix/optional-tags-indicator                                             |
| Bug fix?      | yes                                                                                                                    |
| New feature?  | no                                                                   |
| Deprecations? |no                                                  |
| Issues        | Fix #318 |

Atualmente, é possível criar e editar entidades sem preencher o campo "Tags", já que ele não é obrigatório. No entanto, o site indica erroneamente que o campo é obrigatório. Este PR remove o asterisco de obrigatoriedade.

**Antes**
![before](https://github.com/secultce/mapacultural/assets/113113171/03284d24-1c0a-4814-912d-137d57b9d9ad)

**Depois**
![after](https://github.com/secultce/mapacultural/assets/113113171/8952f60d-474f-45d7-83ed-09231ff20e32)
