### PR TITLE
Add warning message for empty tag insertion

### DIFF
--- a/src/modules/Entities/components/entity-terms/script.js
+++ b/src/modules/Entities/components/entity-terms/script.js
@@ -19,6 +19,7 @@ app.component('entity-terms', {
             terms: this.definition.terms || [],
             label: this.title || this.definition.name,
             filter: '',
+            warningMessage: false,
         };
     },
 
@@ -84,8 +85,14 @@ app.component('entity-terms', {
 
     methods: {
         insertTag(toggleModal) {
-            this.addTerm(this.filter);
+            if (0 === this.filter.trim().length) {
+                this.warningMessage = true;
+                return;
+            }
+
+            this.addTerm(this.filter.trim());
             this.filter = '';
+            this.warningMessage = false;
             toggleModal();
         },
         loadTerms() {

--- a/src/modules/Entities/components/entity-terms/template.php
+++ b/src/modules/Entities/components/entity-terms/template.php
@@ -29,6 +29,7 @@ $this->import('
 
         <!-- Modo Tags -->
         <template #default="{toggle}">
+            <small class="warning-message" v-if="warningMessage" style="color: red; font-weight: bold"><?= i::__('Não é possível adicionar uma tag vazia') ?></small>
             <div class="entity-terms__tags">
                 <form class="entity-terms__tags--form" @submit.prevent="insertTag(toggle)">
                     <input type="text"  class="input" placeholder="<?= i::__('Adicione uma nova tag') ?>" v-model="filter">

--- a/src/translations/empty.po
+++ b/src/translations/empty.po
@@ -6835,6 +6835,10 @@ msgstr ""
 msgid "Adicione uma nova tag"
 msgstr ""
 
+#: modules/Entities/components/entity-terms/template.php:33
+msgid "Não é possível inserir uma tag vazia."
+msgstr ""
+
 #: modules/Entities/views/agent/edit-1.php:47
 #: modules/Entities/views/agent/edit-2.php:46
 #: modules/Entities/views/agent/single-1.php:42

--- a/src/translations/es_AR.po
+++ b/src/translations/es_AR.po
@@ -7322,6 +7322,10 @@ msgstr "Puedes <strong>publicar</strong> nuevamente para desarchivarla."
 msgid "Adicionar nova"
 msgstr "Agregar nueva"
 
+#: src/modules/Entities/components/entity-terms/template.php:32
+msgid "Não é possível adicionar uma tag vazia"
+msgstr "No es posible agregar una etiqueta vacía"
+
 #: src/modules/Entities/components/entity-terms/template.php:34
 msgid "Adicione uma nova tag"
 msgstr "Agregar una nueva etiqueta"

--- a/src/translations/es_ES.po
+++ b/src/translations/es_ES.po
@@ -14217,6 +14217,9 @@ msgstr "Acerca del Sitio"
 #~ msgid "A descrição curta deve ter no máximo 2000 caracteres"
 #~ msgstr "La breve descripción debe tener un máximo de 2000 caracteres"
 
+#~ msgid "Não é possível adicionar uma tag vazia"
+#~ msgstr "No es posible añadir una etiqueta vacía"
+
 #~ msgid "Seguir"
 #~ msgstr "Seguir"
 


### PR DESCRIPTION
| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Branch?       | fix/empty-tags                                            |
| Bug fix?      | yes/no                                                                                                                    |
| New feature?  | no                                                                |
| Deprecations? | no                                        |
| Issues        | Fix #327  |

Impede a criação de tags vazias por usuários e exibe uma mensagem informando que a ação não é permitida. A mensagem só aparece quando uma tag vazia é tentada ser criada. Também foi adicionado a tradução da mensagem para espanhol

![tag](https://github.com/user-attachments/assets/794881be-54f1-4c09-9625-969666666870)

![tagError](https://github.com/user-attachments/assets/67fb577a-9b8f-4740-9be6-d777f18dd6c1)
