### PR TITLE
Standardize social media fields to accept both URLs and URIs.

### DIFF
--- a/app/src/Enum/SocialMediaEnum.php
+++ b/app/src/Enum/SocialMediaEnum.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enum;
+
+enum SocialMediaEnum: string
+{
+    case FACEBOOK = 'facebook.com';
+    case INSTAGRAM = 'instagram.com';
+    case LINKEDIN = 'linkedin.com';
+    case PINTEREST = 'pinterest.com';
+    case SPOTIFY = 'spotify.com';
+    case X = 'x.com';
+    case VIMEO = 'vimeo.com';
+    case YOUTUBE = 'youtube.com';
+    case TIKTOK = 'tiktok.com';
+
+    public function getParsingRegex(): string
+    {
+        return match ($this) {
+            self::FACEBOOK, self::INSTAGRAM, self::PINTEREST, self::VIMEO => "/(?:{$this->value}\/(?:profile\.php\?id=)?|^)([\w\d\.]+)$/i",
+
+            self::X, self::YOUTUBE, self::TIKTOK => "/(?:{$this->value}\/|^)(@?[\w\d\.]+)$/i",
+
+            self::LINKEDIN => "/(?:{$this->value}\/in\/|^)([\w\d-]+)$/i",
+
+            self::SPOTIFY => "/(?:open\.)?spotify\.com\/(?:intl-\w+\/)?(?:(user|artist)\/([\w\d]+))|^(user|artist)\/([\w\d]+)$/i",
+        };
+    }
+}

--- a/src/conf/agent-types.php
+++ b/src/conf/agent-types.php
@@ -1,6 +1,7 @@
 <?php
 
- use MapasCulturais\Utils;
+use App\Enum\SocialMediaEnum;
+use MapasCulturais\Utils;
 
 /**
  * See https://github.com/Respect/Validation to know how to write validations
@@ -433,24 +434,36 @@ return array(
             'type' => "socialMedia",
             'label' => \MapasCulturais\i::__('Facebook'),
             'serialize' =>function($value){
-                return Utils::parseSocialMediaUser('facebook.com', $value);
+                return Utils::parseSocialMediaUser(SocialMediaEnum::FACEBOOK, $value);
             },
             'validations' => array(
                 "v::oneOf(v::urlDomain('facebook.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL válida ou o nome ou id do usuário.")
             ),
-            'placeholder' => "nomedousuario ou iddousuario",
+            'placeholder' => "Url ou id do usuário",
             'available_for_opportunities' => true
         ),
         'twitter' => array(
             'type' => "socialMedia",
             'label' => \MapasCulturais\i::__('Twitter'),
             'serialize' =>function($value){
-                return Utils::parseSocialMediaUser('twitter.com', $value);
+                return Utils::parseSocialMediaUser(SocialMediaEnum::X, $value);
             },
             'validations' => array(
-                "v::oneOf(v::urlDomain('twitter.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
+                "v::oneOf(v::urlDomain('x.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
             ),
-            'placeholder' => "nomedousuario",
+            'placeholder' => "Url ou id do usuário",
+            'available_for_opportunities' => true
+        ),
+        'x' => array(
+            'type' => "socialMedia",
+            'label' => \MapasCulturais\i::__('X'),
+            'serialize' =>function($value){
+                return Utils::parseSocialMediaUser(SocialMediaEnum::X, $value);
+            },
+            'validations' => array(
+                "v::oneOf(v::urlDomain('x.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
+            ),
+            'placeholder' => "Url ou id do usuário",
             'available_for_opportunities' => true
         ),
         'instagram' => array(
@@ -458,23 +471,23 @@ return array(
             'label' => \MapasCulturais\i::__('Instagram'),
             'available_for_opportunities' => true,
             'serialize' =>function($value){
-                return Utils::parseSocialMediaUser('instagram.com', $value);
+                return Utils::parseSocialMediaUser(SocialMediaEnum::INSTAGRAM, $value);
             },
             'validations' => array(
                 "v::oneOf(v::urlDomain('instagram.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
             ),
-            'placeholder' => "nomedousuario",
+            'placeholder' => "Url ou id do usuário",
         ),
         'linkedin' => array(
             'type' => "socialMedia",
             'label' => \MapasCulturais\i::__('Linkedin'),
             'serialize' =>function($value){
-                return Utils::parseSocialMediaUser('linkedin.com', $value);
+                return Utils::parseSocialMediaUser(SocialMediaEnum::LINKEDIN, $value);
             },
             'validations' => array(
                 "v::oneOf(v::urlDomain('linkedin.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
             ),
-            'placeholder' => "nomedousuario",
+            'placeholder' => "Url ou id do usuário",
             'available_for_opportunities' => true
         ),
         'vimeo' => array(
@@ -484,21 +497,21 @@ return array(
                 "v::oneOf(v::urlDomain('vimeo.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
             ),
             'serialize' =>function($value){
-                return Utils::parseSocialMediaUser('vimeo.com', $value);
+                return Utils::parseSocialMediaUser(SocialMediaEnum::VIMEO, $value);
             },
-            'placeholder' => "nomedousuario",
+            'placeholder' => "Url ou id do usuário",
             'available_for_opportunities' => true
         ),
         'spotify' => array(
             'type' => "socialMedia",
             'label' => \MapasCulturais\i::__('Spotify'),
             'validations' => array(
-                "v::oneOf(v::urlDomain('spotify.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
+                "v::oneOf(v::urlDomain('spotify.com'), v::regex('/(?:open\.)?spotify\.com\/(?:intl-\w+\/)?(?:(user|artist)\/([\w\d]+))|^(user|artist)\/([\w\d]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
             ),
             'serialize' =>function($value){
-                return Utils::parseSocialMediaUser('spotify.com', $value);
+                return Utils::parseSocialMediaUser(SocialMediaEnum::SPOTIFY, $value);
             },
-            'placeholder' => "nomedousuario",
+            'placeholder' => "Url ou user/id ou artist/id",
             'available_for_opportunities' => true
         ),
         'youtube' => array(
@@ -508,9 +521,9 @@ return array(
                 "v::oneOf(v::urlDomain('youtube.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
             ),
             'serialize' =>function($value){
-                return Utils::parseSocialMediaUser('youtube.com', $value);
+                return Utils::parseSocialMediaUser(SocialMediaEnum::YOUTUBE, $value);
             },
-            'placeholder' => "iddocanal",
+            'placeholder' => "Url ou id do canal",
             'available_for_opportunities' => true
         ),
         'pinterest' => array(
@@ -520,9 +533,21 @@ return array(
                 "v::oneOf(v::urlDomain('pinterest.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
             ),
             'serialize' =>function($value){
-                return Utils::parseSocialMediaUser('pinterest.com', $value);
+                return Utils::parseSocialMediaUser(SocialMediaEnum::PINTEREST, $value);
             },
-            'placeholder' => "nomedousuario",
+            'placeholder' => "Url ou id do usuário",
+            'available_for_opportunities' => true
+        ),
+        'tiktok' => array(
+            'type' => "socialMedia",
+            'label' => \MapasCulturais\i::__('TikTok'),
+            'validations' => array(
+                "v::oneOf(v::urlDomain('tiktok.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
+            ),
+            'serialize' =>function($value){
+                return Utils::parseSocialMediaUser(SocialMediaEnum::TIKTOK, $value);
+            },
+            'placeholder' => "Url ou id do usuário",
             'available_for_opportunities' => true
         ),
         // DADOS BANCÁRIOS

--- a/src/conf/event-types.php
+++ b/src/conf/event-types.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enum\SocialMediaEnum;
 use MapasCulturais\Utils;
 /**
  * See https://github.com/Respect/Validation to know how to write validations
@@ -72,24 +73,36 @@ return array(
             'type' => "socialMedia",
             'label' => \MapasCulturais\i::__('Facebook'),
             'serialize' =>function($value){
-                return Utils::parseSocialMediaUser('facebook.com', $value);
+                return Utils::parseSocialMediaUser(SocialMediaEnum::FACEBOOK, $value);
             },
             'validations' => array(
                 "v::oneOf(v::urlDomain('facebook.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL válida ou o nome ou id do usuário.")
             ),
-            'placeholder' => "nomedousuario",
+            'placeholder' => "Url ou id do usuário",
             'available_for_opportunities' => true
         ),
         'twitter' => array(
             'type' => "socialMedia",
             'label' => \MapasCulturais\i::__('Twitter'),
             'serialize' =>function($value){
-                return Utils::parseSocialMediaUser('twitter.com', $value);
+                return Utils::parseSocialMediaUser(SocialMediaEnum::X, $value);
             },
             'validations' => array(
-                "v::oneOf(v::urlDomain('twitter.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
+                "v::oneOf(v::urlDomain('x.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
             ),
-            'placeholder' => "nomedousuario",
+            'placeholder' => "Url ou id do usuário",
+            'available_for_opportunities' => true
+        ),
+        'x' => array(
+            'type' => "socialMedia",
+            'label' => \MapasCulturais\i::__('X'),
+            'serialize' =>function($value){
+                return Utils::parseSocialMediaUser(SocialMediaEnum::X, $value);
+            },
+            'validations' => array(
+                "v::oneOf(v::urlDomain('x.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
+            ),
+            'placeholder' => "Url ou id do usuário",
             'available_for_opportunities' => true
         ),
         'instagram' => array(
@@ -97,71 +110,83 @@ return array(
             'label' => \MapasCulturais\i::__('Instagram'),
             'available_for_opportunities' => true,
             'serialize' =>function($value){
-                return Utils::parseSocialMediaUser('instagram.com', $value);
+                return Utils::parseSocialMediaUser(SocialMediaEnum::INSTAGRAM, $value);
             },
             'validations' => array(
                 "v::oneOf(v::urlDomain('instagram.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
             ),
-            'placeholder' => "nomedousuario",
+            'placeholder' => "Url ou id do usuário",
         ),
         'linkedin' => array(
             'type' => "socialMedia",
             'label' => \MapasCulturais\i::__('Linkedin'),
             'serialize' =>function($value){
-                return Utils::parseSocialMediaUser('linkedin.com', $value);
+                return Utils::parseSocialMediaUser(SocialMediaEnum::LINKEDIN, $value);
             },
             'validations' => array(
                 "v::oneOf(v::urlDomain('linkedin.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
             ),
-            'placeholder' => "nomedousuario",
+            'placeholder' => "Url ou id do usuário",
             'available_for_opportunities' => true
         ),
         'vimeo' => array(
-             'type' => "socialMedia",
+            'type' => "socialMedia",
             'label' => \MapasCulturais\i::__('Vimeo'),
             'validations' => array(
                 "v::oneOf(v::urlDomain('vimeo.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
             ),
             'serialize' =>function($value){
-                return Utils::parseSocialMediaUser('vimeo.com', $value);
+                return Utils::parseSocialMediaUser(SocialMediaEnum::VIMEO, $value);
             },
-            'placeholder' => "nomedousuario",
+            'placeholder' => "Url ou id do usuário",
             'available_for_opportunities' => true
         ),
         'spotify' => array(
-              'type' => "socialMedia",
+            'type' => "socialMedia",
             'label' => \MapasCulturais\i::__('Spotify'),
             'validations' => array(
-                "v::oneOf(v::urlDomain('spotify.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
+                "v::oneOf(v::urlDomain('spotify.com'), v::regex('/(?:open\.)?spotify\.com\/(?:intl-\w+\/)?(?:(user|artist)\/([\w\d]+))|^(user|artist)\/([\w\d]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
             ),
             'serialize' =>function($value){
-                return Utils::parseSocialMediaUser('spotify.com', $value);
+                return Utils::parseSocialMediaUser(SocialMediaEnum::SPOTIFY, $value);
             },
-            'placeholder' => "nomedousuario",
+            'placeholder' => "Url ou user/id ou artist/id",
             'available_for_opportunities' => true
         ),
         'youtube' => array(
-              'type' => "socialMedia",
+            'type' => "socialMedia",
             'label' => \MapasCulturais\i::__('YouTube'),
             'validations' => array(
                 "v::oneOf(v::urlDomain('youtube.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
             ),
             'serialize' =>function($value){
-                return Utils::parseSocialMediaUser('youtube.com', $value);
+                return Utils::parseSocialMediaUser(SocialMediaEnum::YOUTUBE, $value);
             },
-            'placeholder' => "nomedousuario",
+            'placeholder' => "Url ou id do canal",
             'available_for_opportunities' => true
         ),
         'pinterest' => array(
-              'type' => "socialMedia",
+            'type' => "socialMedia",
             'label' => \MapasCulturais\i::__('Pinterest'),
             'validations' => array(
                 "v::oneOf(v::urlDomain('pinterest.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
             ),
             'serialize' =>function($value){
-                return Utils::parseSocialMediaUser('pinterest.com', $value);
+                return Utils::parseSocialMediaUser(SocialMediaEnum::PINTEREST, $value);
             },
-            'placeholder' => "nomedousuario",
+            'placeholder' => "Url ou id do usuário",
+            'available_for_opportunities' => true
+        ),
+        'tiktok' => array(
+            'type' => "socialMedia",
+            'label' => \MapasCulturais\i::__('TikTok'),
+            'validations' => array(
+                "v::oneOf(v::urlDomain('tiktok.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
+            ),
+            'serialize' =>function($value){
+                return Utils::parseSocialMediaUser(SocialMediaEnum::TIKTOK, $value);
+            },
+            'placeholder' => "Url ou id do usuário",
             'available_for_opportunities' => true
         ),
         'event_attendance' => array(

--- a/src/conf/opportunity-types.php
+++ b/src/conf/opportunity-types.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enum\SocialMediaEnum;
 use MapasCulturais\Utils;
 /**
  * See https://github.com/Respect/Validation to know how to write validations
@@ -102,24 +103,36 @@ return array(
             'type' => "socialMedia",
             'label' => \MapasCulturais\i::__('Facebook'),
             'serialize' =>function($value){
-                return Utils::parseSocialMediaUser('facebook.com', $value);
+                return Utils::parseSocialMediaUser(SocialMediaEnum::FACEBOOK, $value);
             },
             'validations' => array(
                 "v::oneOf(v::urlDomain('facebook.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL válida ou o nome ou id do usuário.")
             ),
-            'placeholder' => "nomedousuario ou iddousuario",
+            'placeholder' => "Url ou id do usuário",
             'available_for_opportunities' => true
         ),
         'twitter' => array(
             'type' => "socialMedia",
             'label' => \MapasCulturais\i::__('Twitter'),
             'serialize' =>function($value){
-                return Utils::parseSocialMediaUser('twitter.com', $value);
+                return Utils::parseSocialMediaUser(SocialMediaEnum::X, $value);
             },
             'validations' => array(
-                "v::oneOf(v::urlDomain('twitter.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
+                "v::oneOf(v::urlDomain('x.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
             ),
-            'placeholder' => "nomedousuario",
+            'placeholder' => "Url ou id do usuário",
+            'available_for_opportunities' => true
+        ),
+        'x' => array(
+            'type' => "socialMedia",
+            'label' => \MapasCulturais\i::__('X'),
+            'serialize' =>function($value){
+                return Utils::parseSocialMediaUser(SocialMediaEnum::X, $value);
+            },
+            'validations' => array(
+                "v::oneOf(v::urlDomain('x.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
+            ),
+            'placeholder' => "Url ou id do usuário",
             'available_for_opportunities' => true
         ),
         'instagram' => array(
@@ -127,23 +140,23 @@ return array(
             'label' => \MapasCulturais\i::__('Instagram'),
             'available_for_opportunities' => true,
             'serialize' =>function($value){
-                return Utils::parseSocialMediaUser('instagram.com', $value);
+                return Utils::parseSocialMediaUser(SocialMediaEnum::INSTAGRAM, $value);
             },
             'validations' => array(
                 "v::oneOf(v::urlDomain('instagram.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
             ),
-            'placeholder' => "nomedousuario",
+            'placeholder' => "Url ou id do usuário",
         ),
         'linkedin' => array(
             'type' => "socialMedia",
             'label' => \MapasCulturais\i::__('Linkedin'),
             'serialize' =>function($value){
-                return Utils::parseSocialMediaUser('linkedin.com', $value);
+                return Utils::parseSocialMediaUser(SocialMediaEnum::LINKEDIN, $value);
             },
             'validations' => array(
                 "v::oneOf(v::urlDomain('linkedin.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
             ),
-            'placeholder' => "nomedousuario",
+            'placeholder' => "Url ou id do usuário",
             'available_for_opportunities' => true
         ),
         'vimeo' => array(
@@ -153,21 +166,21 @@ return array(
                 "v::oneOf(v::urlDomain('vimeo.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
             ),
             'serialize' =>function($value){
-                return Utils::parseSocialMediaUser('vimeo.com', $value);
+                return Utils::parseSocialMediaUser(SocialMediaEnum::VIMEO, $value);
             },
-            'placeholder' => "nomedousuario",
+            'placeholder' => "Url ou id do usuário",
             'available_for_opportunities' => true
         ),
         'spotify' => array(
             'type' => "socialMedia",
             'label' => \MapasCulturais\i::__('Spotify'),
             'validations' => array(
-                "v::oneOf(v::urlDomain('spotify.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
+                "v::oneOf(v::urlDomain('spotify.com'), v::regex('/(?:open\.)?spotify\.com\/(?:intl-\w+\/)?(?:(user|artist)\/([\w\d]+))|^(user|artist)\/([\w\d]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
             ),
             'serialize' =>function($value){
-                return Utils::parseSocialMediaUser('spotify.com', $value);
+                return Utils::parseSocialMediaUser(SocialMediaEnum::SPOTIFY, $value);
             },
-            'placeholder' => "nomedousuario",
+            'placeholder' => "Url ou user/id ou artist/id",
             'available_for_opportunities' => true
         ),
         'youtube' => array(
@@ -177,9 +190,9 @@ return array(
                 "v::oneOf(v::urlDomain('youtube.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
             ),
             'serialize' =>function($value){
-                return Utils::parseSocialMediaUser('youtube.com', $value);
+                return Utils::parseSocialMediaUser(SocialMediaEnum::YOUTUBE, $value);
             },
-            'placeholder' => "iddocanal",
+            'placeholder' => "Url ou id do canal",
             'available_for_opportunities' => true
         ),
         'pinterest' => array(
@@ -189,9 +202,21 @@ return array(
                 "v::oneOf(v::urlDomain('pinterest.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
             ),
             'serialize' =>function($value){
-                return Utils::parseSocialMediaUser('pinterest.com', $value);
+                return Utils::parseSocialMediaUser(SocialMediaEnum::PINTEREST, $value);
             },
-            'placeholder' => "nomedousuario",
+            'placeholder' => "Url ou id do usuário",
+            'available_for_opportunities' => true
+        ),
+        'tiktok' => array(
+            'type' => "socialMedia",
+            'label' => \MapasCulturais\i::__('TikTok'),
+            'validations' => array(
+                "v::oneOf(v::urlDomain('tiktok.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
+            ),
+            'serialize' =>function($value){
+                return Utils::parseSocialMediaUser(SocialMediaEnum::TIKTOK, $value);
+            },
+            'placeholder' => "Url ou id do usuário",
             'available_for_opportunities' => true
         ),
         'registrationSeals' => array(

--- a/src/conf/project-types.php
+++ b/src/conf/project-types.php
@@ -1,6 +1,7 @@
 <?php
 
- use MapasCulturais\Utils;
+use App\Enum\SocialMediaEnum;
+use MapasCulturais\Utils;
 
 /**
  * See https://github.com/Respect/Validation to know how to write validations
@@ -65,24 +66,36 @@ return array(
             'type' => "socialMedia",
             'label' => \MapasCulturais\i::__('Facebook'),
             'serialize' =>function($value){
-                return Utils::parseSocialMediaUser('facebook.com', $value);
+                return Utils::parseSocialMediaUser(SocialMediaEnum::FACEBOOK, $value);
             },
             'validations' => array(
                 "v::oneOf(v::urlDomain('facebook.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL válida ou o nome ou id do usuário.")
             ),
-            'placeholder' => "nomedousuario ou iddousuario",
+            'placeholder' => "Url ou id do usuário",
             'available_for_opportunities' => true
         ),
         'twitter' => array(
             'type' => "socialMedia",
             'label' => \MapasCulturais\i::__('Twitter'),
             'serialize' =>function($value){
-                return Utils::parseSocialMediaUser('twitter.com', $value);
+                return Utils::parseSocialMediaUser(SocialMediaEnum::X, $value);
             },
             'validations' => array(
-                "v::oneOf(v::urlDomain('twitter.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
+                "v::oneOf(v::urlDomain('x.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
             ),
-            'placeholder' => "nomedousuario",
+            'placeholder' => "Url ou id do usuário",
+            'available_for_opportunities' => true
+        ),
+        'x' => array(
+            'type' => "socialMedia",
+            'label' => \MapasCulturais\i::__('X'),
+            'serialize' =>function($value){
+                return Utils::parseSocialMediaUser(SocialMediaEnum::X, $value);
+            },
+            'validations' => array(
+                "v::oneOf(v::urlDomain('x.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
+            ),
+            'placeholder' => "Url ou id do usuário",
             'available_for_opportunities' => true
         ),
         'instagram' => array(
@@ -90,23 +103,23 @@ return array(
             'label' => \MapasCulturais\i::__('Instagram'),
             'available_for_opportunities' => true,
             'serialize' =>function($value){
-                return Utils::parseSocialMediaUser('instagram.com', $value);
+                return Utils::parseSocialMediaUser(SocialMediaEnum::INSTAGRAM, $value);
             },
             'validations' => array(
                 "v::oneOf(v::urlDomain('instagram.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
             ),
-            'placeholder' => "nomedousuario",
+            'placeholder' => "Url ou id do usuário",
         ),
         'linkedin' => array(
             'type' => "socialMedia",
             'label' => \MapasCulturais\i::__('Linkedin'),
             'serialize' =>function($value){
-                return Utils::parseSocialMediaUser('linkedin.com', $value);
+                return Utils::parseSocialMediaUser(SocialMediaEnum::LINKEDIN, $value);
             },
             'validations' => array(
                 "v::oneOf(v::urlDomain('linkedin.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
             ),
-            'placeholder' => "nomedousuario",
+            'placeholder' => "Url ou id do usuário",
             'available_for_opportunities' => true
         ),
         'vimeo' => array(
@@ -116,21 +129,21 @@ return array(
                 "v::oneOf(v::urlDomain('vimeo.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
             ),
             'serialize' =>function($value){
-                return Utils::parseSocialMediaUser('vimeo.com', $value);
+                return Utils::parseSocialMediaUser(SocialMediaEnum::VIMEO, $value);
             },
-            'placeholder' => "nomedousuario",
+            'placeholder' => "Url ou id do usuário",
             'available_for_opportunities' => true
         ),
         'spotify' => array(
             'type' => "socialMedia",
             'label' => \MapasCulturais\i::__('Spotify'),
             'validations' => array(
-                "v::oneOf(v::urlDomain('spotify.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
+                "v::oneOf(v::urlDomain('spotify.com'), v::regex('/(?:open\.)?spotify\.com\/(?:intl-\w+\/)?(?:(user|artist)\/([\w\d]+))|^(user|artist)\/([\w\d]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
             ),
             'serialize' =>function($value){
-                return Utils::parseSocialMediaUser('spotify.com', $value);
+                return Utils::parseSocialMediaUser(SocialMediaEnum::SPOTIFY, $value);
             },
-            'placeholder' => "nomedousuario",
+            'placeholder' => "Url ou user/id ou artist/id",
             'available_for_opportunities' => true
         ),
         'youtube' => array(
@@ -140,9 +153,9 @@ return array(
                 "v::oneOf(v::urlDomain('youtube.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
             ),
             'serialize' =>function($value){
-                return Utils::parseSocialMediaUser('youtube.com', $value);
+                return Utils::parseSocialMediaUser(SocialMediaEnum::YOUTUBE, $value);
             },
-            'placeholder' => "iddocanal",
+            'placeholder' => "Url ou id do canal",
             'available_for_opportunities' => true
         ),
         'pinterest' => array(
@@ -152,9 +165,21 @@ return array(
                 "v::oneOf(v::urlDomain('pinterest.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
             ),
             'serialize' =>function($value){
-                return Utils::parseSocialMediaUser('pinterest.com', $value);
+                return Utils::parseSocialMediaUser(SocialMediaEnum::PINTEREST, $value);
             },
-            'placeholder' => "nomedousuario",
+            'placeholder' => "Url ou id do usuário",
+            'available_for_opportunities' => true
+        ),
+        'tiktok' => array(
+            'type' => "socialMedia",
+            'label' => \MapasCulturais\i::__('TikTok'),
+            'validations' => array(
+                "v::oneOf(v::urlDomain('tiktok.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
+            ),
+            'serialize' =>function($value){
+                return Utils::parseSocialMediaUser(SocialMediaEnum::TIKTOK, $value);
+            },
+            'placeholder' => "Url ou id do usuário",
             'available_for_opportunities' => true
         ),
 

--- a/src/conf/space-types.php
+++ b/src/conf/space-types.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enum\SocialMediaEnum;
 use MapasCulturais\Utils;
 /**
  * See https://github.com/Respect/Validation to know how to write validations
@@ -441,24 +442,36 @@ return array(
             'type' => "socialMedia",
             'label' => \MapasCulturais\i::__('Facebook'),
             'serialize' =>function($value){
-                return Utils::parseSocialMediaUser('facebook.com', $value);
+                return Utils::parseSocialMediaUser(SocialMediaEnum::FACEBOOK, $value);
             },
             'validations' => array(
                 "v::oneOf(v::urlDomain('facebook.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL válida ou o nome ou id do usuário.")
             ),
-            'placeholder' => "nomedousuario ou iddousuario",
+            'placeholder' => "Url ou id do usuário",
             'available_for_opportunities' => true
         ),
         'twitter' => array(
             'type' => "socialMedia",
             'label' => \MapasCulturais\i::__('Twitter'),
             'serialize' =>function($value){
-                return Utils::parseSocialMediaUser('twitter.com', $value);
+                return Utils::parseSocialMediaUser(SocialMediaEnum::X, $value);
             },
             'validations' => array(
-                "v::oneOf(v::urlDomain('twitter.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
+                "v::oneOf(v::urlDomain('x.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
             ),
-            'placeholder' => "nomedousuario",
+            'placeholder' => "Url ou id do usuário",
+            'available_for_opportunities' => true
+        ),
+        'x' => array(
+            'type' => "socialMedia",
+            'label' => \MapasCulturais\i::__('X'),
+            'serialize' =>function($value){
+                return Utils::parseSocialMediaUser(SocialMediaEnum::X, $value);
+            },
+            'validations' => array(
+                "v::oneOf(v::urlDomain('x.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
+            ),
+            'placeholder' => "Url ou id do usuário",
             'available_for_opportunities' => true
         ),
         'instagram' => array(
@@ -466,23 +479,23 @@ return array(
             'label' => \MapasCulturais\i::__('Instagram'),
             'available_for_opportunities' => true,
             'serialize' =>function($value){
-                return Utils::parseSocialMediaUser('instagram.com', $value);
+                return Utils::parseSocialMediaUser(SocialMediaEnum::INSTAGRAM, $value);
             },
             'validations' => array(
                 "v::oneOf(v::urlDomain('instagram.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
             ),
-            'placeholder' => "nomedousuario",
+            'placeholder' => "Url ou id do usuário",
         ),
         'linkedin' => array(
             'type' => "socialMedia",
             'label' => \MapasCulturais\i::__('Linkedin'),
             'serialize' =>function($value){
-                return Utils::parseSocialMediaUser('linkedin.com', $value);
+                return Utils::parseSocialMediaUser(SocialMediaEnum::LINKEDIN, $value);
             },
             'validations' => array(
                 "v::oneOf(v::urlDomain('linkedin.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
             ),
-            'placeholder' => "nomedousuario",
+            'placeholder' => "Url ou id do usuário",
             'available_for_opportunities' => true
         ),
         'vimeo' => array(
@@ -492,21 +505,21 @@ return array(
                 "v::oneOf(v::urlDomain('vimeo.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
             ),
             'serialize' =>function($value){
-                return Utils::parseSocialMediaUser('vimeo.com', $value);
+                return Utils::parseSocialMediaUser(SocialMediaEnum::VIMEO, $value);
             },
-            'placeholder' => "nomedousuario",
+            'placeholder' => "Url ou id do usuário",
             'available_for_opportunities' => true
         ),
         'spotify' => array(
             'type' => "socialMedia",
             'label' => \MapasCulturais\i::__('Spotify'),
             'validations' => array(
-                "v::oneOf(v::urlDomain('spotify.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
+                "v::oneOf(v::urlDomain('spotify.com'), v::regex('/(?:open\.)?spotify\.com\/(?:intl-\w+\/)?(?:(user|artist)\/([\w\d]+))|^(user|artist)\/([\w\d]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
             ),
             'serialize' =>function($value){
-                return Utils::parseSocialMediaUser('spotify.com', $value);
+                return Utils::parseSocialMediaUser(SocialMediaEnum::SPOTIFY, $value);
             },
-            'placeholder' => "nomedousuario",
+            'placeholder' => "Url ou user/id ou artist/id",
             'available_for_opportunities' => true
         ),
         'youtube' => array(
@@ -516,9 +529,9 @@ return array(
                 "v::oneOf(v::urlDomain('youtube.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
             ),
             'serialize' =>function($value){
-                return Utils::parseSocialMediaUser('youtube.com', $value);
+                return Utils::parseSocialMediaUser(SocialMediaEnum::YOUTUBE, $value);
             },
-            'placeholder' => "iddocanal",
+            'placeholder' => "Url ou id do canal",
             'available_for_opportunities' => true
         ),
         'pinterest' => array(
@@ -528,9 +541,21 @@ return array(
                 "v::oneOf(v::urlDomain('pinterest.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
             ),
             'serialize' =>function($value){
-                return Utils::parseSocialMediaUser('pinterest.com', $value);
+                return Utils::parseSocialMediaUser(SocialMediaEnum::PINTEREST, $value);
             },
-            'placeholder' => "nomedousuario",
+            'placeholder' => "Url ou id do usuário",
+            'available_for_opportunities' => true
+        ),
+        'tiktok' => array(
+            'type' => "socialMedia",
+            'label' => \MapasCulturais\i::__('TikTok'),
+            'validations' => array(
+                "v::oneOf(v::urlDomain('tiktok.com'), v::regex('/^@?([\w\d\.]+)$/i'))" => \MapasCulturais\i::__("O valor deve ser uma URL ou usuário válido.")
+            ),
+            'serialize' =>function($value){
+                return Utils::parseSocialMediaUser(SocialMediaEnum::TIKTOK, $value);
+            },
+            'placeholder' => "Url ou id do usuário",
             'available_for_opportunities' => true
         ),
 

--- a/src/modules/Components/assets/js/components-base/Utils.js
+++ b/src/modules/Components/assets/js/components-base/Utils.js
@@ -256,6 +256,17 @@ globalThis.Utils = {
     },
 
     buildSocialMediaLink(entity, socialMedia){
-        return "https://" + socialMedia + ".com/" + entity[socialMedia];
+        let baseUrl = "https://" + socialMedia + ".com/";
+
+        switch (socialMedia) {
+            case 'linkedin':
+                baseUrl = "https://www.linkedin.com/in/";
+                break;
+            case 'spotify':
+                baseUrl = `https://open.spotify.com/`;
+                break;
+        }
+
+        return baseUrl + entity[socialMedia];
     }
 }

--- a/src/modules/Components/components/mc-icon/init.php
+++ b/src/modules/Components/components/mc-icon/init.php
@@ -21,10 +21,11 @@ $iconset = [
     'pinterest' => 'fa6-brands:pinterest-p',
     'spotify' => 'akar-icons:spotify-fill',
     'telegram' => 'cib:telegram-plane',
-    'twitter' => 'akar-icons:twitter-fill',
+    'x' => 'fa6-brands:x-twitter',
     'whatsapp' => 'akar-icons:whatsapp-fill',
     'vimeo' => 'brandico:vimeo',
     'youtube' => 'akar-icons:youtube-fill',
+    'tiktok' => 'bxl:tiktok',
 
 
     // IMPORTANTE: manter ordem alfabética

--- a/src/modules/Components/components/mc-share-links/template.php
+++ b/src/modules/Components/components/mc-share-links/template.php
@@ -12,8 +12,8 @@
         <a  class="fa fa-twitter" 
             title="Share on Tweet" target="_blank" 
             @click="click('twitter')">
-        
-            <mc-icon name="twitter"></mc-icon>
+
+            <mc-icon name="x"></mc-icon>
         </a>   
         
         <a  class="fa fa-facebook" 

--- a/src/modules/Entities/components/entity-header/template.php
+++ b/src/modules/Entities/components/entity-header/template.php
@@ -23,8 +23,13 @@ $this->import('
             <!-- <mc-icon  v-if="!entity.files.avatar" :entity="entity"></mc-icon> -->
             <nav class="share" aria-label="<?= i::__('Compartilhar') ?>">
                 <a v-if="entity.twitter" :href="entity.twitter" class="button button--text button--icon" aria-label="Twitter" target="_blank">
-                    <mc-icon name="twitter"></mc-icon>
+                    <mc-icon name="x"></mc-icon>
                 </a>
+
+                <a v-if="entity.x" :href="entity.twitter" class="button button--text button--icon" aria-label="Twitter" target="_blank">
+                    <mc-icon name="x"></mc-icon>
+                </a>
+
                 <a v-if="entity.linkedin" :href="entity.linkedin" class="button button--text button--icon" aria-label="Linkedin" target="_blank">
                     <mc-icon name="linkedin"></mc-icon>
                 </a>

--- a/src/modules/Entities/components/entity-social-media/script.js
+++ b/src/modules/Entities/components/entity-social-media/script.js
@@ -3,7 +3,7 @@ app.component('entity-social-media', {
 
     data() {
         return {
-            show: !!(this.entity.instagram || this.entity.twitter || this.entity.vimeo || this.entity.linkedin || this.entity.facebook || this.entity.youtube || this.entity.spotify || this.entity.pinterest),
+            show: !!(this.entity.instagram || this.entity.twitter || this.entity.vimeo || this.entity.linkedin || this.entity.facebook || this.entity.youtube || this.entity.spotify || this.entity.pinterest || this.entity.x || this.entity.tiktok),
         }
     },
 

--- a/src/modules/Entities/components/entity-social-media/template.php
+++ b/src/modules/Entities/components/entity-social-media/template.php
@@ -18,14 +18,20 @@ $this->import('
             <a target="_blank" :href="buildSocialMediaLink('instagram')">{{entity.instagram}}</a>
         </div>
 
-        <div v-if="entity.twitter" class="entity-social-media__links--link">
-            <mc-icon name="twitter"></mc-icon>
-            <a target="_blank" :href="buildSocialMediaLink('twitter')">{{entity.twitter}}</a>
+        <div v-if="entity.twitter || entity.x" class="entity-social-media__links--link">
+            <mc-icon name="x"></mc-icon>
+            <a v-if="entity.x" target="_blank" :href="buildSocialMediaLink('x')">{{entity.x}}</a>
+            <a v-if="entity.twitter" target="_blank" :href="buildSocialMediaLink('twitter')">{{entity.twitter}}</a>
         </div>
 
         <div v-if="entity.facebook" class="entity-social-media__links--link">
             <mc-icon name="facebook"></mc-icon>
             <a target="_blank" :href="buildSocialMediaLink('facebook')">{{entity.facebook}}</a>
+        </div>
+
+        <div v-if="entity.tiktok" class="entity-social-media__links--link">
+            <mc-icon name="tiktok"></mc-icon>
+            <a target="_blank" :href="buildSocialMediaLink('tiktok')">{{entity.tiktok}}</a>
         </div>
 
         <div v-if="entity.youtube" class="entity-social-media__links--link">
@@ -45,7 +51,7 @@ $this->import('
 
         <div v-if="entity.spotify" class="entity-social-media__links--link">
             <mc-icon name="spotify"></mc-icon>
-            <a target="_blank" :href="buildSocialMediaLink('spotify')">{{entity.spotify}}</a>
+            <a target="_blank" :href="buildSocialMediaLink('spotify')">{{entity.name}}</a>
         </div>
 
         <div v-if="entity.pinterest" class="entity-social-media__links--link">
@@ -63,8 +69,13 @@ $this->import('
             <entity-field :entity="entity" prop="instagram"></entity-field>
         </div>
 
-        <div class="entity-social-media__edit--link">
-            <mc-icon name="twitter"></mc-icon>
+        <div class="entity-social-media__edit--link" v-if="!entity.twitter">
+            <mc-icon name="x"></mc-icon>
+            <entity-field :entity="entity" prop="x"></entity-field>
+        </div>
+
+        <div class="entity-social-media__edit--link" v-if="entity.twitter">
+            <mc-icon name="x"></mc-icon>
             <entity-field :entity="entity" prop="twitter"></entity-field>
         </div>
 
@@ -74,8 +85,8 @@ $this->import('
         </div>
 
         <div class="entity-social-media__edit--link">
-            <mc-icon name="vimeo"></mc-icon>
-            <entity-field :entity="entity" prop="vimeo"></entity-field>
+            <mc-icon name="tiktok"></mc-icon>
+            <entity-field :entity="entity" prop="tiktok"></entity-field>
         </div>
 
         <div class="entity-social-media__edit--link">
@@ -96,6 +107,11 @@ $this->import('
         <div class="entity-social-media__edit--link">
             <mc-icon name="pinterest"></mc-icon>
             <entity-field :entity="entity" prop="pinterest"></entity-field>
+        </div>
+
+        <div class="entity-social-media__edit--link">
+            <mc-icon name="vimeo"></mc-icon>
+            <entity-field :entity="entity" prop="vimeo"></entity-field>
         </div>
     </div>
 </div>


### PR DESCRIPTION
| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Branch?       | improvement/social-media-links                                               |
| Bug fix?      | yes                                                                                                                    |
| New feature?  | yes                                                                   |
| Deprecations? | yes                                                  |
| Issues        | Fix #357  |

Neste PR, criei um enum de redes sociais que contém as expressões regulares necessárias para a validação de URLs e usuários das redes sociais, veja as alterações em [SocialMediaEnum.php](https://github.com/secultce/mapacultural/pull/374/files#diff-a69b3ca23c067fba44cd31796a7b6eeff2bf02e066368ae358c5067bad1ef751).

Refatorei o método parseSocialMediaUser, utilizando Object Calisthenics e boas práticas, e incrementei o método para aceitar diferentes tipos de URLs do Spotify, tanto de artistas quanto de usuários comuns. Além disso, alterei a função buildSocialMediaLink para que ela construa URLs corretamente para outras redes sociais, como Spotify e LinkedIn, veja as alterações em [Utils.php](https://github.com/secultce/mapacultural/pull/374/files#diff-9c4340008ed421c1c1c8e0c29f934b8ddc22161443bd04084270ce5ac7cddbfd) e [Utils.js](https://github.com/secultce/mapacultural/pull/374/files#diff-ca00ee7b9fc840e9471ddcbedea1f91fb87be31524efa5629bab055515fcbaab).

Removi o ícone do Twitter e adicionei o novo ícone do X, além de criar um novo campo para incluir o TikTok.

![socialEdit](https://github.com/user-attachments/assets/32b6b74f-0312-4426-b6b6-76995d0e640a)


![socialLink](https://github.com/user-attachments/assets/f860cc6c-db5d-463f-b239-7cbc8fe80835)

Atualizei o ícone do X no componente entity-header, mas notei que os links nesse mesmo componente estão com o href apontando para a URL errada. Este problema será corrigido em um novo PR.